### PR TITLE
Add topics list with Provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:google_fonts/google_fonts.dart';
+
 import 'l10n/l10n.dart';
+import 'screens/home.dart';
 
 void main() {
   runApp(const DailyUpApp());
@@ -30,126 +32,7 @@ class DailyUpApp extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const HabitListPage(),
-    );
-  }
-}
-
-class HabitItem {
-  HabitItem({required this.icon, required this.title});
-  final String icon;
-  final String title;
-  bool done = false;
-}
-
-class HabitListPage extends StatefulWidget {
-  const HabitListPage({super.key});
-
-  @override
-  State<HabitListPage> createState() => _HabitListPageState();
-}
-
-class _HabitListPageState extends State<HabitListPage> {
-  final List<HabitItem> _habits = [
-    HabitItem(icon: '🌞', title: 'morningStretch'),
-    HabitItem(icon: '📖', title: 'reading'),
-    HabitItem(icon: '🧘', title: 'deepBreathing'),
-  ];
-
-  final TextEditingController _controller = TextEditingController();
-
-  @override
-  Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          loc.translate('appTitle'),
-          style: GoogleFonts.fredoka(fontWeight: FontWeight.bold, fontSize: 24),
-        ),
-        centerTitle: true,
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: ListView.builder(
-          itemCount: _habits.length,
-          itemBuilder: (context, index) {
-            final item = _habits[index];
-            return Dismissible(
-              key: ValueKey(item),
-              direction: DismissDirection.endToStart,
-              background: Container(
-                alignment: Alignment.centerRight,
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                color: Colors.redAccent,
-                child: const Icon(Icons.delete, color: Colors.white),
-              ),
-              onDismissed: (_) => setState(() => _habits.removeAt(index)),
-              child: Card(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                elevation: 2,
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Row(
-                    children: [
-                      Text(item.icon, style: const TextStyle(fontSize: 24)),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Text(
-                          loc.translate(item.title),
-                          style: GoogleFonts.fredoka(fontSize: 18),
-                        ),
-                      ),
-                      Checkbox(
-                        value: item.done,
-                        onChanged: (value) {
-                          setState(() {
-                            item.done = value ?? false;
-                          });
-                        },
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            );
-          },
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: Colors.pinkAccent,
-        child: const Icon(Icons.add),
-        onPressed: () async {
-          _controller.clear();
-          final result = await showDialog<String>(
-            context: context,
-            builder: (context) => AlertDialog(
-              title: Text(loc.addHabit),
-              content: TextField(
-                controller: _controller,
-                decoration: InputDecoration(hintText: loc.habitNameHint),
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: Text(loc.cancel),
-                ),
-                TextButton(
-                  onPressed: () => Navigator.pop(context, _controller.text),
-                  child: Text(loc.add),
-                ),
-              ],
-            ),
-          );
-          if (result != null && result.isNotEmpty) {
-            setState(() {
-              _habits.add(HabitItem(icon: '❤️', title: result));
-            });
-          }
-        },
-      ),
+      home: const HomePage(),
     );
   }
 }

--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -1,0 +1,15 @@
+class Topic {
+  Topic({required this.title, required this.link, required this.publishedAt});
+
+  final String title;
+  final String link;
+  final DateTime publishedAt;
+
+  factory Topic.fromJson(Map<String, dynamic> json) {
+    return Topic(
+      title: json['title'] as String? ?? '',
+      link: json['link'] as String? ?? '',
+      publishedAt: DateTime.tryParse(json['published_at']?.toString() ?? '') ?? DateTime.now(),
+    );
+  }
+}

--- a/lib/providers/topics_provider.dart
+++ b/lib/providers/topics_provider.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/topic.dart';
+
+class TopicsProvider extends ChangeNotifier {
+  TopicsProvider({http.Client? client}) : _client = client ?? http.Client();
+
+  static const String baseUrl = 'https://example.com';
+
+  final http.Client _client;
+
+  final List<Topic> _topics = [];
+  List<Topic> get topics => List.unmodifiable(_topics);
+
+  bool isLoading = false;
+  bool hasError = false;
+  int _page = 1;
+  bool _hasMore = true;
+
+  Future<void> fetch({required String category}) async {
+    _page = 1;
+    _topics.clear();
+    _hasMore = true;
+    await _load(category: category);
+  }
+
+  Future<void> loadMore({required String category}) async {
+    if (!_hasMore || isLoading) return;
+    _page++;
+    await _load(category: category);
+  }
+
+  Future<void> _load({required String category}) async {
+    isLoading = true;
+    hasError = false;
+    notifyListeners();
+    try {
+      final uri = Uri.parse(
+          '$baseUrl/api/v1/topics?category=$category&page=$_page');
+      final response = await _client.get(uri);
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        final items = data['topics'] as List<dynamic>? ?? [];
+        for (final item in items) {
+          _topics.add(Topic.fromJson(item as Map<String, dynamic>));
+        }
+        _hasMore = items.isNotEmpty;
+      } else {
+        hasError = true;
+      }
+    } catch (_) {
+      hasError = true;
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/topics_provider.dart';
+import 'topics_list.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  final _controller = TextEditingController(text: 'news');
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(
+                labelText: 'Category',
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                final category = _controller.text.trim();
+                if (category.isEmpty) return;
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => ChangeNotifierProvider(
+                      create: (_) => TopicsProvider()..fetch(category: category),
+                      child: TopicsListPage(category: category),
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Show Topics'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/topic_detail.dart
+++ b/lib/screens/topic_detail.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../models/topic.dart';
+
+class TopicDetailPage extends StatelessWidget {
+  const TopicDetailPage({super.key, required this.topic});
+
+  final Topic topic;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Topic Detail')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(topic.title, style: Theme.of(context).textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            Text('Published: ${topic.publishedAt.toLocal()}'),
+            const SizedBox(height: 16),
+            InkWell(
+              onTap: () async {
+                final uri = Uri.parse(topic.link);
+                if (await canLaunchUrl(uri)) {
+                  await launchUrl(uri);
+                }
+              },
+              child: Text(
+                topic.link,
+                style: const TextStyle(color: Colors.blue),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/topics_list.dart
+++ b/lib/screens/topics_list.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/topics_provider.dart';
+import '../models/topic.dart';
+import 'topic_detail.dart';
+
+class TopicsListPage extends StatefulWidget {
+  const TopicsListPage({super.key, required this.category});
+
+  final String category;
+
+  @override
+  State<TopicsListPage> createState() => _TopicsListPageState();
+}
+
+class _TopicsListPageState extends State<TopicsListPage> {
+  late final ScrollController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ScrollController()
+      ..addListener(() {
+        if (_controller.position.pixels >=
+                _controller.position.maxScrollExtent - 200) {
+          Provider.of<TopicsProvider>(context, listen: false)
+              .loadMore(category: widget.category);
+        }
+      });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Topics: ${widget.category}')),
+      body: Consumer<TopicsProvider>(
+        builder: (context, provider, _) {
+          if (provider.isLoading && provider.topics.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (provider.hasError && provider.topics.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('Failed to load'),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: () => provider.fetch(category: widget.category),
+                    child: const Text('Retry'),
+                  )
+                ],
+              ),
+            );
+          }
+          return RefreshIndicator(
+            onRefresh: () => provider.fetch(category: widget.category),
+            child: ListView.builder(
+              controller: _controller,
+              itemCount: provider.topics.length + (provider.isLoading ? 1 : 0),
+              itemBuilder: (context, index) {
+                if (index == provider.topics.length) {
+                  return const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+                final topic = provider.topics[index];
+                return ListTile(
+                  title: Text(topic.title),
+                  subtitle: Text(topic.publishedAt.toLocal().toString()),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => TopicDetailPage(topic: topic),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,10 @@ dependencies:
     sdk: flutter
   google_fonts: ^6.1.0
 
+  provider: ^6.1.1
+  http: ^0.13.6
+  url_launcher: ^6.1.10
+
   cupertino_icons: ^1.0.6
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- enable provider, http and url_launcher
- implement TopicsProvider for API calls with pagination
- add Home, TopicsList and TopicDetail screens
- remove old habit example and show HomePage as start

## Testing
- `flutter pub get` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b699cae6c833090acbf76d07656f9